### PR TITLE
Fix embedding calculation

### DIFF
--- a/colab/SaprotHub.ipynb
+++ b/colab/SaprotHub.ipynb
@@ -2948,7 +2948,7 @@
         "  embedding_list = []\n",
         "  with torch.no_grad():\n",
         "    for seq in tqdm(seqs, total=len(seqs)):\n",
-        "      embedding = model.get_hidden_states_from_seqs(seqs, reduction='mean')\n",
+        "      embedding = model.get_hidden_states_from_seqs([seq], reduction='mean')\n",
         "      embedding_list.append(embedding[0])\n",
         "  embeddings = torch.stack(embedding_list)\n",
         "  # print(embeddings.shape)\n",


### PR DESCRIPTION
There seems to be a typo/bug in the embeddings calculation code that was leading to all output tensors for a group of sequences being the same.